### PR TITLE
Move hand-written index.d.ts into src

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Contentful GmbH",
   "license": "MIT",
   "main": "built/index",
+  "types": "built/index.d.ts",
   "keywords": [
     "contentful",
     "content model",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,32 @@
-import { runMigration } from './bin/cli'
-
-module.exports = { runMigration }
+export type {
+  RunMigrationConfig,
+  Movement,
+  EditorLayoutMovement,
+  IFieldOptions,
+  Field,
+  IValidation,
+  WidgetSettingsValue,
+  IEditorInterfaceOptions,
+  ISidebarWidgetSettings,
+  IFieldGroupWidgetSettings,
+  ContentType,
+  InitFieldGroupOptions,
+  FieldGroupUpdateFunction,
+  FieldGroup,
+  EditorLayout,
+  IContentTypeOptions,
+  ITransformEntriesConfig,
+  ITransformEntriesToTypeConfig,
+  IDeriveLinkedEntriesConfig,
+  ITag,
+  ITagOptions,
+  ITagLink,
+  ISetTagsForEntriesConfig,
+  ClientConfig,
+  MakeRequest,
+  MigrationContext,
+  MigrationFunction
+} from './types'
+import type Migration from './types'
+export default Migration
+export { runMigration } from './bin/cli'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import * as axios from 'axios'
+import type * as axios from 'axios'
 
 export type RunMigrationConfig = {
   accessToken?: string
@@ -8,9 +8,10 @@ export type RunMigrationConfig = {
   rawProxy?: boolean
   yes?: boolean
   retryLimit?: number
+  managementApplication?: string
+  managementFeature?: string
+  quiet?: boolean
 } & ({ filePath: string } | { migrationFunction: MigrationFunction })
-
-export function runMigration(config: RunMigrationConfig): Promise<any>
 
 export interface Movement {
   toTheTop(): void
@@ -187,6 +188,7 @@ export interface IFieldGroupWidgetSettings {
   [setting: string]: WidgetSettingsValue
 }
 
+// TODO: should we just import the one from contentful-management?
 export interface ContentType {
   id: string
   instanceId: string


### PR DESCRIPTION
This allows us to rely on those typings within the implementation.
So far, the only place we do this is in cli.ts, for runMigration